### PR TITLE
Update the gas price to the new change of the chain 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anchor-protocol/anchor-earn",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Anchor Protocol",
   "license": "MIT",
   "repository": "github:Anchor-Protocol/anchor-earn",

--- a/src/data/anchorearn-default-columbus.ts
+++ b/src/data/anchorearn-default-columbus.ts
@@ -5,9 +5,9 @@ const mainNetDefaultConfig: AnchorConfig = {
     URL: 'https://lcd.terra.dev',
     chainID: 'columbus-4',
     gasPrices: {
-      uusd: 0.15,
+      uusd: 0.38,
     },
-    gasAdjustment: 1.4,
+    gasAdjustment: 2,
   },
   contracts: {
     mmMarket: 'terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s',


### PR DESCRIPTION
gas price on the chain has been changed to the new amount in the mainnet and anchor-earn must be compatible with it